### PR TITLE
Switch to blocks/inlines from marks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import { findDOMNode } from 'slate';
 
 import Portal from './lib/Portal';
 import {
@@ -23,7 +24,13 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
 
   return {
     schema: {
-      marks: {
+      nodes: {
+        default: ({ attributes, children }) => (
+          <span {...attributes}>{children}</span>
+        ),
+        line: ({ attributes, children }) => (
+          <span {...attributes}>{children}</span>
+        ),
         mention: Mention,
       },
     },
@@ -43,8 +50,12 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
           // Guard selectedIndex to be within the length of the suggestions
           const selected =
             (suggestions && selectedIndex % suggestions.length) || 0;
+
+          // const node = state.startBlock.getMarksAtRange(state.selection).findLast(mark => mark.type === 'mention');
+          // console.log(node)
+          // console.log(findDOMNode(node))
           portal = (
-            <Portal node={state.endText}>
+            <Portal node={state.startBlock}>
               <Suggestions
                 selected={selected}
                 suggestions={editor.props.suggestions}
@@ -66,7 +77,7 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
         // If the user types an @ we add a mention mark if we're not already in one
         case AT_SIGN: {
           if (currentlyInMention(state)) return;
-          return state.transform().addMark('mention').apply();
+          return state.transform().insertBlock('mention').focus().apply();
         }
         // If we're in a mention and either space or enter are pressed
         // jump out of the mention and insert a space
@@ -92,7 +103,8 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
               .transform()
               .deleteBackward(mentionLength)
               .insertText(text)
-              .removeMark('mention')
+              .splitBlock()
+              .setBlock('default')
               .insertText(' ')
               .focus()
               .apply();

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import { findDOMNode } from 'slate';
 
 import Portal from './lib/Portal';
 import {
@@ -51,9 +50,6 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
           const selected =
             (suggestions && selectedIndex % suggestions.length) || 0;
 
-          // const node = state.startBlock.getMarksAtRange(state.selection).findLast(mark => mark.type === 'mention');
-          // console.log(node)
-          // console.log(findDOMNode(node))
           portal = (
             <Portal node={state.startBlock}>
               <Suggestions

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import { FIRST_MENTION } from './constants';
 
 export const currentlyInMention = (state: Object) =>
-  state.marks.some(mark => mark.type === 'mention');
+  state.blocks.some(block => block.type === 'mention');
 
 // Find the index of the nearest "@" going backwards in text from end index
 export const nearestAt = (text: string, end: number) => {


### PR DESCRIPTION
This PR switches `mentions` to be blocks. This is necessary to be able to position the suggestion portal right next to the mention.

The problem with this PR is that getting this to work correctly requires us to override the `line` and `default` nodes to be `span`s, which is obviously not optimal:tm: as it'll break a bunch of folks editors.

I tried using `setInline`/`splitInline`/... instead of `setBlock`/... but for some reason that didn't do anything. Maybe @ianstormtaylor has an idea why this exact change with `xInline` rather than `xBlock` doesn't work?

/cc @oyeanuj