### PR TITLE
Make it possible to serialize editor state automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ updateSuggestions = (text) => {
 }
 ```
 
+## Serialization
+
+To serialize your editor state the mentions plugin provides `serializationRules` adapted for your custom `Mention` component:
+
+```JS
+import { Html } from 'slate';
+import MentionPlugin from 'slate-mentions';
+
+// Create the plugin as usual
+const mentions = MentionPlugin({
+  Mention: MentionComponent,
+  Suggestions: SuggestionsComponent,
+});
+
+const { serialize } = new Html({
+  // Add the mentions serialization rules after any of your custom ones
+  rules: [...mentions.serializationRules]
+});
+
+// Get your current editor state as HTML 🎉
+serialize(editor.state);
+
+// You can also get your current editor state as React components:
+serialize(editor.state, { render: false });
+```
+
 ## License
 
 Licensed under the MIT License, Copyright ©️ 2017 Maximilian Stoiber. See [LICENSE.md](LICENSE.md) for more information.

--- a/src/create-serialization-rules.js
+++ b/src/create-serialization-rules.js
@@ -1,0 +1,18 @@
+// @flow
+import type { SlateSchema, SerializationRule } from './types';
+
+export default (schema: SlateSchema): Array<SerializationRule> => {
+  if (!schema.nodes) return [];
+
+  return Object.keys(schema.nodes).map(name => ({
+    serialize: (node: any, children: any): any => {
+      if (node.type === name && schema.nodes && schema.nodes[name]) {
+        return schema.nodes[name]({
+          ...node,
+          children,
+        });
+      }
+      return null;
+    },
+  }));
+};

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import {
   SELECTED_MENTION_INDEX_KEY,
 } from './constants';
 import { currentlyInMention, findNearestMention, nearestAt } from './utils';
+import createSerializationRules from './create-serialization-rules';
 import type { Options, SlatePlugin } from './types';
 
 const MentionsPlugin = (options?: Options): SlatePlugin => {
@@ -21,18 +22,21 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
   }
   const { Mention, Suggestions } = options;
 
-  return {
-    schema: {
-      nodes: {
-        default: ({ attributes, children }) => (
-          <span {...attributes}>{children}</span>
-        ),
-        line: ({ attributes, children }) => (
-          <span {...attributes}>{children}</span>
-        ),
-        mention: Mention,
-      },
+  const schema = {
+    nodes: {
+      default: ({ attributes, children }) => (
+        <span {...attributes}>{children}</span>
+      ),
+      line: ({ attributes, children }) => (
+        <span {...attributes}>{children}</span>
+      ),
+      mention: Mention,
     },
+  };
+
+  return {
+    schema,
+    serializationRules: createSerializationRules(schema),
     render(props: Object, state: Object, editor: Object) {
       let portal = null;
       if (currentlyInMention(state)) {

--- a/src/types.js
+++ b/src/types.js
@@ -15,7 +15,12 @@ export type Options = {
   Suggestions: ReactClass<SuggestionsComponentProps>,
 };
 
-type SlateSchema = {
+export type SerializationRule = {
+  deserialize?: () => ReactClass<>,
+  serialize?: () => ReactClass<>,
+};
+
+export type SlateSchema = {
   nodes?: Object,
   marks?: Object,
   rules?: Array<any>,


### PR DESCRIPTION
Rather than manually adding serialization rules for this plugin users can now do this:

```JS
import { Html } from 'slate';
import MentionPlugin from 'slate-mentions';

// Create the plugin as usual
const mentions = MentionPlugin({
  Mention: MentionComponent,
  Suggestions: SuggestionsComponent,
});

const { serialize } = new Html({
  // Add the mentions serialization rules after any of your custom ones
  rules: [...mentions.serializationRules]
});

// Get your current editor state as HTML 🎉
serialize(editor.state);

// You can also get your current editor state as React components:
serialize(editor.state, { render: false });
```

The `serialize-to-react-component`-thing seems like a much better option for rendering messages, rather than rendering thousands of read-only editors. Am I right in assuming that's a better approach @ianstormtaylor?