### PR TITLE
Add onlyIn and ignoreIn options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The plugin has two required options:
 - `Mention`: The component to render a mention mark in the editor. This gets two props (`attributes` and `children`), and `props.attributes` must be attached to the DOM node. (just like any other Slate mark)
 - `Suggestions`: The component to render the suggestions as a list. This is already in a portal that's positioned next to the mention. This component gets three props: `suggestions` (the list of suggestions), `selected` (the index of the currently selected mention via keyboard shortcuts) and `mention`. (the search text)
 
+You can also set the following optional options:
+- `ignoreIn`: An array of block types to **not** trigger mentions inside.
+- `onlyIn` — An array of block types to **only** trigger mentions inside.
+
 
 After passing these two options to the plugin and adding it to the plugins array you have to pass two special props to the Slate `Editor` component:
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
       '[Slate] [MentionsPlugin] Please provide the Mention and Suggestions components via the options.'
     );
   }
-  const { Mention, Suggestions } = options;
+  const { Mention, Suggestions, onlyIn, ignoreIn } = options;
 
   return {
     schema: {
@@ -62,6 +62,11 @@ const MentionsPlugin = (options?: Options): SlatePlugin => {
       );
     },
     onKeyDown(event: KeyboardEvent, data: any, state: Object, editor: Object) {
+      const { startBlock } = state;
+      const { type } = startBlock;
+      if (onlyIn && !onlyIn.includes(type)) return;
+      if (ignoreIn && ignoreIn.includes(type)) return;
+
       switch (event.which) {
         // If the user types an @ we add a mention mark if we're not already in one
         case AT_SIGN: {

--- a/src/types.js
+++ b/src/types.js
@@ -13,6 +13,8 @@ export type SuggestionsComponentProps = {
 export type Options = {
   Mention: ReactClass<MentionComponentProps>,
   Suggestions: ReactClass<SuggestionsComponentProps>,
+  onlyIn: Array<string>,
+  ignoreIn: Array<string>,
 };
 
 type SlateSchema = {


### PR DESCRIPTION
Hey Max, Adding a couple of options to allow more control to the user to decide where they need the mentions (for example, not in headings). Its a pattern I found in @ianstormtaylor's plugins that I liked and use quite a bit in my own plugins.

I haven't been able to test in the examples due to #6, but once I/you do, then it is good to merge.

