### PR TITLE
Add react-dom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "positions": "^1.6.1",
     "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "react-portal": "^3.1.0",
     "slate": "^0.19.29"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,7 +2822,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -2859,6 +2859,15 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
 react-portal@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Not sure what is going on with react-portal requiring react-dom. It doesn't seem like slate-mentions should directly depend on react-dom at all. Oh well. This fixes the issue with the example at least.